### PR TITLE
Npm

### DIFF
--- a/lib/rules/no-unsupported-keywords.js
+++ b/lib/rules/no-unsupported-keywords.js
@@ -16,12 +16,12 @@ function checkExpression(context, expression, allKeywords) {
   var calleeText = source.getText(expression);
   var assertionText = calleeText.substr(expectText.length + 1);
 
-  var keywords = assertionText.split(/[\.\s]/).filter(function (k) {
+  var keywords = assertionText.split(/[.\s]/).filter(function (k) {
     return !!k;
   });
   for (var i = 0; i < keywords.length; i++) {
     var keyword = keywords[i];
-    if (!allKeywords.hasOwnProperty(keyword)) {
+    if (!{}.hasOwnProperty.call(allKeywords, keyword)) {
       return context.report({
         node: property,
         message: '"' + assertionText + '" contains unknown keyword "' + keyword + '"'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "eslint-plugin-chai-expect-keywords",
   "version": "1.0.0",
   "author": "Gavin Aiken <gavin@aiken.org.uk>",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "description": "ESLint plugin that checks for chai.js expect() assertions using non-existent keywords",
   "main": "index.js",
   "scripts": {
@@ -21,9 +24,13 @@
   },
   "homepage": "https://github.com/gavinaiken/eslint-plugin-chai-expect-keywords",
   "bugs": "https://github.com/gavinaiken/eslint-plugin-chai-expect-keywords/issues",
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "dependencies": {},
   "devDependencies": {
-    "eslint": "^3.19.0",
-    "mocha": "^3.0.2"
+    "eslint": "^6.8.0",
+    "mocha": "^7.0.1"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Builds on #4 and #5.

- Linting (ESLint): Update per latest eslint recommended
- npm: Add recommended properties (`contributors`, `dependencies`)
- npm: Add `engines` pointing tentatively to >=6.0.0
- npm: Update devDeps (resolves vulnerabilities)

I arbitrary chose 6.0.0 for `engines` as it is around the version which you already support (e.g., your use of `reduce` wouldn't allow the earliest Node versions I think, though https://node.green doesn't cover that), yet it is high enough to possibly also start using some other nice features. Let me know if you want to bump that even higher, e.g., to Node 8 or even 10 (as 8 has just reached End-of-Life, some projects are dropping support). Setting up Travis/CI would help to make sure we are indeed passing tests there if you felt inclined to set that up.
