### PR TITLE
Coverage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "eslint:recommended",
   "env": {
+    "es6": true,
     "node": true
   },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint ./",
     "test": "npm run lint && npm run unit-test",
-    "unit-test": "mocha tests/**/*.js"
+    "unit-test": "nyc mocha tests/**/*.js"
   },
   "files": [
     "LICENSE",
@@ -30,7 +30,8 @@
   "dependencies": {},
   "devDependencies": {
     "eslint": "^6.8.0",
-    "mocha": "^7.0.1"
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0"
   },
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-unsupported-keywords.js
+++ b/tests/lib/rules/no-unsupported-keywords.js
@@ -6,80 +6,74 @@ var RuleTester = require('eslint').RuleTester;
 var ruleTester = new RuleTester();
 ruleTester.run('no-unsupported-keywords', rule, {
   valid: [{
-    code: [
-      'it("works as expected", function() {',
-      '  expect(true).to.be.ok;',
-      '});'
-    ].join('\n')
+    code: `
+      it("works as expected", function() {
+        expect(true).to.be.ok;
+      });
+      `
   }, {
-    code: [
-      'it("works as expected", function() {',
-      '  expect(true)',
-      '  .to.be.ok;',
-      '});'
-    ].join('\n')
+    code: `
+      it("works as expected", function() {
+        expect(true)
+        .to.be.ok;
+      });
+    `
   }, {
-    code: [
-      'foobar();'
-    ].join('\n')
+    code: 'foobar;'
   }, {
-    code: [
-      'foobar.ok();'
-    ].join('\n')
+    code: 'foobar();'
   }, {
-    code: [
-      'expect(obj);'
-    ].join('\n')
+    code: 'foobar.ok();'
   }, {
-    code: [
-      'expect(obj).ok;'
-    ].join('\n')
+    code: 'expect(obj);'
+  }, {
+    code: 'expect(obj).ok;'
   }, {
     code: 'expect(something).to.equal(somethingElse);'
   }],
 
   invalid: [{
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(true).to.be.foo();',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(true).to.be.foo();
+      });
+    `,
     errors: [{
       message: '"to.be.foo" contains unknown keyword "foo"'
     }]
   }, {
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(true).foo();',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(true).foo();
+      });
+    `,
     errors: [{
       message: '"foo" contains unknown keyword "foo"'
     }]
   }, {
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(true).foo;',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(true).foo;
+      });
+    `,
     errors: [{
       message: '"foo" contains unknown keyword "foo"'
     }]
   }, {
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(true).to.not.zing.be.false();',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(true).to.not.zing.be.false();
+      });
+    `,
     errors: [{
       message: '"to.not.zing.be.false" contains unknown keyword "zing"'
     }]
   }, {
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(true).to.not.zing.be.false;',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(true).to.not.zing.be.false;
+      });
+    `,
     errors: [{
       message: '"to.not.zing.be.false" contains unknown keyword "zing"'
     }]
@@ -89,37 +83,37 @@ ruleTester.run('no-unsupported-keywords', rule, {
 ruleTester.run('no-unsupported-keywords with options', rule, {
   valid: [{
     options: [{allowKeywords: ['zing', 'foo']}],
-    code: [
-      'it("works as expected", function() {',
-      '  expect(result).to.be.foo();',
-      '  expect(result).to.zing.be.ok;',
-      '});'
-    ].join('\n')
+    code: `
+      it("works as expected", function() {
+        expect(result).to.be.foo();
+        expect(result).to.zing.be.ok;
+      });
+    `
   }, {
     options: [{allowSinonChai: true}],
-    code: [
-      'it("works as expected", function() {',
-      '  expect(result).to.have.returned(foo);',
-      '  expect(result).to.have.been.called;',
-      '});'
-    ].join('\n')
+    code: `
+      it("works as expected", function() {
+        expect(result).to.have.returned(foo);
+        expect(result).to.have.been.called;
+      });
+    `
   }, {
     options: [{allowChaiAsPromised: true}],
-    code: [
-      'it("works as expected", function() {',
-      '  expect(result).to.eventually.be.ok;',
-      '});'
-    ].join('\n')
+    code: `
+      it("works as expected", function() {
+        expect(result).to.eventually.be.ok;
+      });
+    `
   }],
 
   invalid: [{
     options: [{allowKeywords:['zing', 'foo']}],
-    code: [
-      'it("fails as expected", function() {',
-      '  expect(result).to.be.foo();',
-      '  expect(result).to.bar.be.ok;',
-      '});'
-    ].join('\n'),
+    code: `
+      it("fails as expected", function() {
+        expect(result).to.be.foo();
+        expect(result).to.bar.be.ok;
+      });
+    `,
     errors: [{
       message: '"to.bar.be.ok" contains unknown keyword "bar"'
     }]


### PR DESCRIPTION
Builds on #4, #5, and #6 .

- Testing: Add nyc coverage
- Testing: Add test case for non-matching `ExpressionStatement`, i.e., `foobar;` (bringing to 100% coverage)
- Testing: Use ES6 templates for greater readability

Once these PRs may be accepted/adjusted as desired, I should be able to add #2, though I'll have to see if I can get to fixing all of #1 myself.