### PR TITLE
Chai dom

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; EditorConfig file: https://EditorConfig.org
+; Install the "EditorConfig" plugin into your editor to use
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm install eslint-plugin-chai-expect-keywords
   keywords in the allowed list
 - `allowChaiAsPromised` includes [chai-as-promised](https://github.com/domenic/chai-as-promised)
   keywords in the allowed list
+- `allowChaiDOM` includes [chai-dom](https://github.com/nathanboktae/chai-dom)
+  keywords in the allowed list
 
 # Configuration
 
@@ -55,7 +57,8 @@ Or with options:
     "chai-expect-keywords/no-unsupported-keywords": [ "error", {
       "allowKeywords": ["length"],
       "allowSinonChai": true,
-      "allowChaiAsPromised": true
+      "allowChaiAsPromised": true,
+      "allowChaiDOM": true
     } ]
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = {
         'chai-expect-keywords/no-unsupported-keywords': [
           'error', {
             allowSinonChai: true,
-            allowChaiAsPromised: true
+            allowChaiAsPromised: true,
+            allowChaiDOM: true
           }
         ]
       }

--- a/lib/rules/no-unsupported-keywords.js
+++ b/lib/rules/no-unsupported-keywords.js
@@ -51,6 +51,9 @@ module.exports = {
           },
           allowChaiAsPromised: {
             type: 'boolean'
+          },
+          allowChaiDOM: {
+            type: 'boolean'
           }
         }
       }
@@ -61,7 +64,8 @@ module.exports = {
     var allKeywords = keywords.CHAI.concat(
       options.allowKeywords || [],
       options.allowSinonChai ? keywords.SINON : [],
-      options.allowChaiAsPromised ? keywords.CHAI_AS_PROMISED : []
+      options.allowChaiAsPromised ? keywords.CHAI_AS_PROMISED : [],
+      options.allowChaiDOM ? keywords.CHAI_DOM : []
     ).reduce(function (acc, curr) {
       acc[curr] = true;
       return acc;

--- a/lib/util/keywords.js
+++ b/lib/util/keywords.js
@@ -120,5 +120,25 @@ module.exports = {
   CHAI_AS_PROMISED: [
     'eventually',
     'notify'
+  ],
+
+  CHAI_DOM: [
+    'attr',
+    'attribute',
+    'class',
+    'id',
+    'html',
+    'text',
+    'value',
+    'empty',
+    'length',
+    'exist',
+    'match',
+    'contain',
+    'descendant',
+    'descendants',
+    'displayed',
+    'visible',
+    'tagName'
   ]
 };

--- a/tests/lib/rules/no-unsupported-keywords.js
+++ b/tests/lib/rules/no-unsupported-keywords.js
@@ -104,6 +104,14 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
         expect(result).to.eventually.be.ok;
       });
     `
+  }, {
+    options: [{allowChaiDOM: true}],
+    code: `
+    it("works as expected", function() {
+      expect(result).to.have.text('abc');
+      expect(result).not.be.displayed;
+    });
+    `
   }],
 
   invalid: [{
@@ -116,6 +124,51 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
     `,
     errors: [{
       message: '"to.bar.be.ok" contains unknown keyword "bar"'
+    }]
+  }, {
+    code: `
+      it("works as expected", function() {
+        expect(result).to.be.foo();
+        expect(result).to.zing.be.ok;
+      });
+    `,
+    errors: [{
+      message: '"to.be.foo" contains unknown keyword "foo"'
+    }, {
+      message: '"to.zing.be.ok" contains unknown keyword "zing"'
+    }]
+  }, {
+    code: `
+      it("works as expected", function() {
+        expect(result).to.have.returned(foo);
+        expect(result).to.have.been.called;
+      });
+    `,
+    errors: [{
+      message: '"to.have.returned" contains unknown keyword "returned"'
+    }, {
+      message: '"to.have.been.called" contains unknown keyword "called"'
+    }]
+  }, {
+    code: `
+      it("works as expected", function() {
+        expect(result).to.eventually.be.ok;
+      });
+    `,
+    errors: [{
+      message: '"to.eventually.be.ok" contains unknown keyword "eventually"'
+    }]
+  }, {
+    code: `
+    it("works as expected", function() {
+      expect(result).to.have.text('abc');
+      expect(result).not.be.displayed;
+    });
+    `,
+    errors: [{
+      message: '"to.have.text" contains unknown keyword "text"'
+    }, {
+      message: '"not.be.displayed" contains unknown keyword "displayed"'
     }]
   }]
 });


### PR DESCRIPTION
Builds on #4, #5, #6, #7.

Fixes #2.

- Enhancement: Add `allowChaiDOM` option (and as part of `recommended`)
- Testing: Add invalid versions of the option tests
- Maintenance: Add `.editorconfig`
