### PR TITLE
Chai as promised

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ npm install eslint-plugin-chai-expect-keywords
 - `allowSinonChai` includes [sinon-chai](http://chaijs.com/plugins/sinon-chai/)
   keywords in the allowed list
 - `allowChaiAsPromised` includes [chai-as-promised](https://github.com/domenic/chai-as-promised)
-  keywords in the allowed list
+  keywords in the allowed list. (You may also find [eslint-plugin-chai-as-promised](https://github.com/fintechstudios/eslint-plugin-chai-as-promised) of interest in ensuring
+  that `return` statements (or its `notify` method) are present as expected
+  by `chai-as-promised`.)
 - `allowChaiDOM` includes [chai-dom](https://github.com/nathanboktae/chai-dom)
   keywords in the allowed list
 

--- a/lib/rules/no-unsupported-keywords.js
+++ b/lib/rules/no-unsupported-keywords.js
@@ -71,21 +71,28 @@ module.exports = {
       return acc;
     }, {});
 
+    function checkByExpressionType (expression) {
+      if (expression.type === 'CallExpression') {
+        var callee = expression.callee;
+        if (callee.type !== 'MemberExpression') {
+          return;
+        }
+        return checkExpression(context, callee, allKeywords);
+      }
+      if (expression.type === 'MemberExpression') {
+        return checkExpression(context, expression, allKeywords);
+      }
+      return;
+    }
+
     return {
+      'ReturnStatement[argument]': function (node) {
+        var expression = node.argument;
+        return checkByExpressionType(expression);
+      },
       ExpressionStatement: function (node) {
         var expression = node.expression;
-        if (expression.type === 'CallExpression') {
-          var callee = expression.callee;
-          if (callee.type !== 'MemberExpression') {
-            return;
-          }
-          return checkExpression(context, callee, allKeywords);
-        }
-        if (expression.type === 'MemberExpression') {
-          return checkExpression(context, expression, allKeywords);
-        }
-
-        return;
+        return checkByExpressionType(expression);
       }
     };
   }

--- a/lib/util/keywords.js
+++ b/lib/util/keywords.js
@@ -119,7 +119,11 @@ module.exports = {
 
   CHAI_AS_PROMISED: [
     'eventually',
-    'notify'
+    'notify',
+    'become',
+    'rejectedWith',
+    'fulfilled',
+    'rejected'
   ],
 
   CHAI_DOM: [

--- a/tests/lib/rules/no-unsupported-keywords.js
+++ b/tests/lib/rules/no-unsupported-keywords.js
@@ -7,13 +7,13 @@ var ruleTester = new RuleTester();
 ruleTester.run('no-unsupported-keywords', rule, {
   valid: [{
     code: `
-      it("works as expected", function() {
+      it("works with regular chai keywords", function() {
         expect(true).to.be.ok;
       });
       `
   }, {
     code: `
-      it("works as expected", function() {
+      it("works with regular chai keywords and line break", function() {
         expect(true)
         .to.be.ok;
       });
@@ -34,7 +34,7 @@ ruleTester.run('no-unsupported-keywords', rule, {
 
   invalid: [{
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with non-keyword as chained method", function() {
         expect(true).to.be.foo();
       });
     `,
@@ -43,7 +43,7 @@ ruleTester.run('no-unsupported-keywords', rule, {
     }]
   }, {
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with non-keyword as method", function() {
         expect(true).foo();
       });
     `,
@@ -52,7 +52,16 @@ ruleTester.run('no-unsupported-keywords', rule, {
     }]
   }, {
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with non-keyword as chained property", function() {
+        expect(true).to.be.foo;
+      });
+    `,
+    errors: [{
+      message: '"to.be.foo" contains unknown keyword "foo"'
+    }]
+  }, {
+    code: `
+      it("fails as expected with non-keyword as property", function() {
         expect(true).foo;
       });
     `,
@@ -61,7 +70,7 @@ ruleTester.run('no-unsupported-keywords', rule, {
     }]
   }, {
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with keyword in middle of method chain", function() {
         expect(true).to.not.zing.be.false();
       });
     `,
@@ -70,7 +79,7 @@ ruleTester.run('no-unsupported-keywords', rule, {
     }]
   }, {
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with keyword in middle of property chain", function() {
         expect(true).to.not.zing.be.false;
       });
     `,
@@ -84,7 +93,7 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
   valid: [{
     options: [{allowKeywords: ['zing', 'foo']}],
     code: `
-      it("works as expected", function() {
+      it("works as expected with \`allowKeywords\`", function() {
         expect(result).to.be.foo();
         expect(result).to.zing.be.ok;
       });
@@ -92,7 +101,7 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
   }, {
     options: [{allowSinonChai: true}],
     code: `
-      it("works as expected", function() {
+      it("works as expected with \`allowSinonChai\`", function() {
         expect(result).to.have.returned(foo);
         expect(result).to.have.been.called;
       });
@@ -100,14 +109,33 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
   }, {
     options: [{allowChaiAsPromised: true}],
     code: `
-      it("works as expected", function() {
+      it("works as expected with \`allowChaiAsPromised\`", function() {
         expect(result).to.eventually.be.ok;
+        expect(result).to.be.rejectedWith(foo);
       });
+    `
+  }, {
+    options: [{allowChaiAsPromised: true}],
+    code: `
+    it("works as expected with \`allowChaiAsPromised\` method in a return", function() {
+      return expect(
+        someMethod
+      ).to.be.rejectedWith(TypeError);
+    });
+    `
+  }, {
+    options: [{allowChaiAsPromised: true}],
+    code: `
+    it("works as expected with \`allowChaiAsPromised\` property in a return", function() {
+      return expect(
+        someMethod
+      ).to.eventually.be.ok;
+    });
     `
   }, {
     options: [{allowChaiDOM: true}],
     code: `
-    it("works as expected", function() {
+    it("works as expected with \`allowChaiDOM\`", function() {
       expect(result).to.have.text('abc');
       expect(result).not.be.displayed;
     });
@@ -117,7 +145,7 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
   invalid: [{
     options: [{allowKeywords:['zing', 'foo']}],
     code: `
-      it("fails as expected", function() {
+      it("fails as expected with keyword missing among \`allowKeywords\`", function() {
         expect(result).to.be.foo();
         expect(result).to.bar.be.ok;
       });
@@ -127,7 +155,7 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
     }]
   }, {
     code: `
-      it("works as expected", function() {
+      it("fails as expected when \`allowKeywords\` is missing", function() {
         expect(result).to.be.foo();
         expect(result).to.zing.be.ok;
       });
@@ -139,7 +167,7 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
     }]
   }, {
     code: `
-      it("works as expected", function() {
+      it("fails as expected when \`allowSinonChai\` is missing", function() {
         expect(result).to.have.returned(foo);
         expect(result).to.have.been.called;
       });
@@ -151,16 +179,41 @@ ruleTester.run('no-unsupported-keywords with options', rule, {
     }]
   }, {
     code: `
-      it("works as expected", function() {
+      it("fails as expected when \`allowChaiAsPromised\` is missing", function() {
         expect(result).to.eventually.be.ok;
+        expect(result).to.be.rejectedWith(foo);
       });
+    `,
+    errors: [{
+      message: '"to.eventually.be.ok" contains unknown keyword "eventually"'
+    }, {
+      message: '"to.be.rejectedWith" contains unknown keyword "rejectedWith"'
+    }]
+  }, {
+    code: `
+    it("fails as expected in a return method when \`allowChaiAsPromised\` is missing", function() {
+      return expect(
+        someMethod
+      ).to.be.rejectedWith(TypeError);
+    });
+    `,
+    errors: [{
+      message: '"to.be.rejectedWith" contains unknown keyword "rejectedWith"'
+    }]
+  }, {
+    code: `
+    it("fails as expected in a return property when \`allowChaiAsPromised\` is missing", function() {
+      return expect(
+        someMethod
+      ).to.eventually.be.ok;
+    });
     `,
     errors: [{
       message: '"to.eventually.be.ok" contains unknown keyword "eventually"'
     }]
   }, {
     code: `
-    it("works as expected", function() {
+    it("fails as expected when \`allowChaiDOM\` is missing", function() {
       expect(result).to.have.text('abc');
       expect(result).not.be.displayed;
     });


### PR DESCRIPTION
Builds on #4, #5, #6, #7, #8. Fixes #1.

- Enhancement: Support `ReturnStatement` (often required by chai-as-promised)
- Fix: For `allowChaiAsPromised` option, check other supported properties/methods: 
    `become`, `rejectedWith`, `fulfilled`, `rejected`
- Docs: Makes mention of related tool `eslint-plugin-chai-as-promised`
- Testing: Add tests for `allowChaiAsPromised` option where method is used (as with `chai-as-promised` property)
- Testing: More description inner test descriptions; add test for non-keyword
   as chained property
