### PR TITLE
ES6

### DIFF
--- a/lib/rules/no-unsupported-keywords.js
+++ b/lib/rules/no-unsupported-keywords.js
@@ -1,30 +1,29 @@
 "use strict";
 
-var findExpectCall = require('../util/find-expect-call');
-var keywords = require('../util/keywords');
+const findExpectCall = require('../util/find-expect-call');
+const keywords = require('../util/keywords');
 
 function checkExpression(context, expression, allKeywords) {
 
-  var expectCall = findExpectCall(expression.object);
+  const expectCall = findExpectCall(expression.object);
   if (!expectCall) {
     return;
   }
 
-  var source = context.getSourceCode();
-  var expectText = source.getText(expectCall);
-  var property = expression.property;
-  var calleeText = source.getText(expression);
-  var assertionText = calleeText.substr(expectText.length + 1);
+  const source = context.getSourceCode();
+  const expectText = source.getText(expectCall);
+  const {property} = expression;
+  const calleeText = source.getText(expression);
+  const assertionText = calleeText.substr(expectText.length + 1);
 
-  var keywords = assertionText.split(/[.\s]/).filter(function (k) {
+  const keywords = assertionText.split(/[.\s]/).filter(function (k) {
     return !!k;
   });
-  for (var i = 0; i < keywords.length; i++) {
-    var keyword = keywords[i];
-    if (!{}.hasOwnProperty.call(allKeywords, keyword)) {
+  for (const keyword of keywords) {
+    if (!allKeywords.has(keyword)) {
       return context.report({
         node: property,
-        message: '"' + assertionText + '" contains unknown keyword "' + keyword + '"'
+        message: `"${assertionText}" contains unknown keyword "${keyword}"`
       });
     }
   }
@@ -59,21 +58,18 @@ module.exports = {
       }
     ]
   },
-  create: function (context) {
-    var options = context.options[0] || {};
-    var allKeywords = keywords.CHAI.concat(
+  create (context) {
+    const options = context.options[0] || {};
+    const allKeywords = new Set(keywords.CHAI.concat(
       options.allowKeywords || [],
       options.allowSinonChai ? keywords.SINON : [],
       options.allowChaiAsPromised ? keywords.CHAI_AS_PROMISED : [],
       options.allowChaiDOM ? keywords.CHAI_DOM : []
-    ).reduce(function (acc, curr) {
-      acc[curr] = true;
-      return acc;
-    }, {});
+    ));
 
     function checkByExpressionType (expression) {
       if (expression.type === 'CallExpression') {
-        var callee = expression.callee;
+        const {callee} = expression;
         if (callee.type !== 'MemberExpression') {
           return;
         }
@@ -86,12 +82,12 @@ module.exports = {
     }
 
     return {
-      'ReturnStatement[argument]': function (node) {
-        var expression = node.argument;
+      'ReturnStatement[argument]' (node) {
+        const expression = node.argument;
         return checkByExpressionType(expression);
       },
-      ExpressionStatement: function (node) {
-        var expression = node.expression;
+      ExpressionStatement (node) {
+        const {expression} = node;
         return checkByExpressionType(expression);
       }
     };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/gavinaiken/eslint-plugin-chai-expect-keywords",
   "bugs": "https://github.com/gavinaiken/eslint-plugin-chai-expect-keywords/issues",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.3.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/tests/lib/rules/no-unsupported-keywords.js
+++ b/tests/lib/rules/no-unsupported-keywords.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var rule = require('../../../lib/rules/no-unsupported-keywords');
-var RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/no-unsupported-keywords');
+const {RuleTester} = require('eslint');
 
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 ruleTester.run('no-unsupported-keywords', rule, {
   valid: [{
     code: `


### PR DESCRIPTION
Builds on #8 and #9.

- Breaking change: Bump to Node 8.3.0
- Refactoring: ES6 changes (prefer const/let, for-of, simplify `allKeywords` into a `Set`, method shorthand, object destructuring; use templates further)
