### PR TITLE
Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ avoid the steps of adding to `plugins` and `rules` and just add:
 
 ```json
 {
+  "extends": ["chai-expect-keywords/all"]
+}
+```
+
+Or if you want the rule only with no booleans set, just add:
+
+```json
+{
   "extends": ["chai-expect-keywords/recommended"]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,14 @@ module.exports = {
       plugins: ['chai-expect-keywords'],
       rules: {
         'chai-expect-keywords/no-unsupported-keywords': [
+          'error'
+        ]
+      }
+    },
+    all: {
+      plugins: ['chai-expect-keywords'],
+      rules: {
+        'chai-expect-keywords/no-unsupported-keywords': [
           'error', {
             allowSinonChai: true,
             allowChaiAsPromised: true,


### PR DESCRIPTION
- Breaking change (since recent addition of recommended config): Rename existing "recommended" config to "all" and add a "recommended" config with no booleans set.

Just had the thought that this may be better as far as configs--since the "recommended" way previously may have been too aggressive in allowing keywords that the user might not have installed. If they know they want all the booleans they can now use the "all" config.