### PR TITLE
- Docs: Fix to include reference to necessary "plugin:" prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ avoid the steps of adding to `plugins` and `rules` and just add:
 
 ```json
 {
-  "extends": ["chai-expect-keywords/all"]
+  "extends": ["plugin:chai-expect-keywords/all"]
 }
 ```
 
@@ -79,7 +79,7 @@ Or if you want the rule only with no booleans set, just add:
 
 ```json
 {
-  "extends": ["chai-expect-keywords/recommended"]
+  "extends": ["plugin:chai-expect-keywords/recommended"]
 }
 ```
 


### PR DESCRIPTION
Apologies, the need for this slipped past me.

Btw, the new release appears to be working well (if following these instructions).